### PR TITLE
Copyfix: EKO field value not persisting in Excel

### DIFF
--- a/contract_data.py
+++ b/contract_data.py
@@ -41,6 +41,7 @@ class ContractData:
             'numer_domu': self.house_number,
             'email': self.email or "-",
             'tel': self.phone or "-",
+            'is_eco': self.is_eco,
             'nr': str(contract_number),
             'rok': year
         }


### PR DESCRIPTION
- Add is_eco field to contract_data dictionary
- Ensure EKO value from form is properly passed to Excel